### PR TITLE
Add `Dk::Pkg::Validate` task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry', "~> 0.9.0"
+
+gem 'dk', :git => "git@github.com:redding/dk.git"

--- a/dk-pkg.gemspec
+++ b/dk-pkg.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
 
+  gem.add_dependency("dk", ["~> 0.0.1"])
+
 end

--- a/lib/dk-pkg.rb
+++ b/lib/dk-pkg.rb
@@ -1,5 +1,5 @@
-require "dk-pkg/version"
+require 'dk-pkg/version'
+require 'dk-pkg/constants'
 
-module Dk; end
-module Dk::Pkg
-end
+# require the tasks for convenience
+require 'dk-pkg/validate'

--- a/lib/dk-pkg/constants.rb
+++ b/lib/dk-pkg/constants.rb
@@ -1,0 +1,9 @@
+module Dk; end
+module Dk::Pkg
+
+  MANIFEST_PATH_PARAM_NAME  = 'dk_pkg_manifest_path'.freeze
+  INSTALLED_PKGS_PARAM_NAME = 'dk_pkg_installed_pkgs'.freeze
+
+  MANIFEST_SEPARATOR = "\n".freeze
+
+end

--- a/lib/dk-pkg/validate.rb
+++ b/lib/dk-pkg/validate.rb
@@ -1,0 +1,45 @@
+require 'dk/task'
+require 'dk-pkg/constants'
+
+module Dk::Pkg
+
+  class Validate
+    include Dk::Task
+
+    desc "(dk-pkg) validate the required dk-pkg params"
+
+    run_only_once true
+
+    def run!
+      # validate that a manifest path has been set, so we can parse it
+      if params[MANIFEST_PATH_PARAM_NAME].to_s.empty?
+        raise ArgumentError, "no #{MANIFEST_PATH_PARAM_NAME.inspect} param set"
+      end
+
+      cmd! "touch #{params[MANIFEST_PATH_PARAM_NAME]}"
+      manifest = cmd!("cat #{params[MANIFEST_PATH_PARAM_NAME]}").stdout
+      set_param INSTALLED_PKGS_PARAM_NAME, manifest.split(MANIFEST_SEPARATOR)
+    end
+
+    module TestHelpers
+      include MuchPlugin
+
+      plugin_included do
+        include Dk::Task::TestHelpers
+
+        setup do
+          @dk_pkg_manifest_path  ||= Factory.file_path
+          @dk_pkg_installed_pkgs ||= []
+
+          @params ||= {}
+          @params[MANIFEST_PATH_PARAM_NAME]  ||= @dk_pkg_manifest_path
+          @params[INSTALLED_PKGS_PARAM_NAME] ||= @dk_pkg_installed_pkgs
+        end
+
+      end
+
+    end
+
+  end
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,6 +1,16 @@
 require 'assert/factory'
+require 'dk-pkg/constants'
 
 module Factory
   extend Assert::Factory
+
+  def self.manifest(installed_pkgs = nil)
+    installed_pkgs ||= Factory.installed_pkgs
+    installed_pkgs.join(Dk::Pkg::MANIFEST_SEPARATOR)
+  end
+
+  def self.installed_pkgs
+    Factory.integer(3).times.map{ Factory.string }
+  end
 
 end

--- a/test/unit/dk-pkg_tests.rb
+++ b/test/unit/dk-pkg_tests.rb
@@ -1,0 +1,24 @@
+require 'assert'
+require 'dk-pkg'
+
+module Dk::Pkg
+
+  class UnitTests < Assert::Context
+    desc "Dk::Pkg"
+    setup do
+      @module = Dk::Pkg
+    end
+    subject{ @module }
+
+    should "know its param names" do
+      assert_equal 'dk_pkg_manifest_path',  MANIFEST_PATH_PARAM_NAME
+      assert_equal 'dk_pkg_installed_pkgs', INSTALLED_PKGS_PARAM_NAME
+    end
+
+    should "know its manifest separator" do
+      assert_equal "\n", MANIFEST_SEPARATOR
+    end
+
+  end
+
+end

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -1,0 +1,136 @@
+require 'assert'
+require 'dk-pkg/validate'
+
+require 'dk/task'
+require 'dk-pkg/constants'
+
+class Dk::Pkg::Validate
+
+  class UnitTests < Assert::Context
+    desc "Dk::Pkg::Validate"
+    setup do
+      @task_class = Dk::Pkg::Validate
+    end
+    subject{ @task_class }
+
+    should "be a Dk::Task" do
+      assert_includes Dk::Task, subject
+    end
+
+    should "know its description" do
+      exp = "(dk-pkg) validate the required dk-pkg params"
+      assert_equal exp, subject.description
+    end
+
+    should "only run once" do
+      assert_true subject.run_only_once
+    end
+
+  end
+
+  class RunSetupTests < UnitTests
+    include Dk::Task::TestHelpers
+
+    desc "when run"
+    setup do
+      @manifest_path  = Factory.file_path
+      @installed_pkgs = Factory.installed_pkgs
+
+      @exp_cat_cmd = "cat #{@manifest_path}"
+
+      @params = {
+        Dk::Pkg::MANIFEST_PATH_PARAM_NAME => @manifest_path
+      }
+    end
+    subject{ @runner }
+
+    private
+
+    def stub_cat_manifest_file_cmd(runner, manifest = nil)
+      manifest ||= Factory.manifest(@installed_pkgs)
+      runner.stub_cmd(@exp_cat_cmd){ |s| s.stdout = manifest }
+    end
+
+  end
+
+  class RunTests < RunSetupTests
+    setup do
+      @runner = test_runner(@task_class, :params => @params)
+      stub_cat_manifest_file_cmd(@runner)
+      @runner.run
+    end
+
+    should "parse the manifest file and set the installed pkgs param" do
+      assert_equal 2, subject.runs.size
+
+      touch_cmd, cat_cmd = subject.runs
+      assert_equal "touch #{@manifest_path}", touch_cmd.cmd_str
+      assert_equal @exp_cat_cmd,              cat_cmd.cmd_str
+
+      exp = @installed_pkgs
+      assert_equal exp, subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
+    end
+
+  end
+
+  class RunWithEmptyManifestTests < RunSetupTests
+    desc "and the manifest is empty"
+    setup do
+      @runner = test_runner(@task_class, :params => @params)
+      stub_cat_manifest_file_cmd(@runner, "")
+      @runner.run
+    end
+
+    should "parse the manifest file and set the installed pkgs param" do
+      assert_equal [], subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
+    end
+
+  end
+
+  class RunWithoutManifestPathTests < RunSetupTests
+    desc "and the manifest path param isn't set"
+    setup do
+      @params[Dk::Pkg::MANIFEST_PATH_PARAM_NAME] = [nil, ''].sample
+    end
+
+    should "complain about the param not being set" do
+      runner = test_runner(@task_class, :params => @params)
+      assert_raises(ArgumentError){ runner.run }
+    end
+
+  end
+
+  class TestHelpersTests < UnitTests
+    desc "TestHelpers"
+    setup do
+      @context_class = Class.new do
+        def self.setup_blocks; @setup_blocks ||= []; end
+        def self.setup(&block)
+          self.setup_blocks << block
+        end
+        include Dk::Pkg::Validate::TestHelpers
+        attr_reader :dk_pkg_manifest_path, :dk_pkg_installed_pkgs
+        attr_reader :params
+        def initialize
+          self.class.setup_blocks.each{ |b| self.instance_eval(&b) }
+        end
+      end
+      @context = @context_class.new
+    end
+    subject{ @context }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, @context_class
+    end
+
+    should "setup the ivars and params the validate task does" do
+      exp = subject.dk_pkg_manifest_path
+      assert_equal exp, subject.params[Dk::Pkg::MANIFEST_PATH_PARAM_NAME]
+
+      exp = subject.dk_pkg_installed_pkgs
+      assert_equal exp, subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `Validate` task that is setup for logic that will only
install packages via tasks if they haven't already been installed.

The `Validate` task will be run before any task that uses `Dk::Pkg`
logic to control when packages are installed. `Validate` will
ensure that a manifest path param has been set and will handle
parsing the manifest file. The parsed manifest results in an array
that will be stored in the params as the installed packages.
Eventually this will be used to check if a package has already been
installed and if so the logic to install it won't be run. This will
allow setting up package tasks that depend on one another but will
ensure they are only installed once. This will also allow
re-running a build of many package tasks and ensure it won't try
and reinstall packages.

This also commonizes the `Dk::Pkg` constants so they can be used
by `Validate` and the upcoming logic that controls whether a
package will be installed or not.

@kellyredding - FYI, you've already seen this, I'm just pulling the logic and history out of the repo dk-pkg was developed in. Since it's going to be relatively easy I'd like to keep the commit history of the dk-pkg logic for reference.
