### PR TITLE
Add `InstallPkg` mixin

### DIFF
--- a/dk-pkg.gemspec
+++ b/dk-pkg.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("dk", ["~> 0.0.1"])
+  gem.add_dependency("dk",          ["~> 0.0.1"])
+  gem.add_dependency("much-plugin", ["~> 0.2.0"])
 
 end

--- a/lib/dk-pkg.rb
+++ b/lib/dk-pkg.rb
@@ -1,5 +1,6 @@
 require 'dk-pkg/version'
 require 'dk-pkg/constants'
+require 'dk-pkg/install_pkg'
 
 # require the tasks for convenience
 require 'dk-pkg/validate'

--- a/lib/dk-pkg/install_pkg.rb
+++ b/lib/dk-pkg/install_pkg.rb
@@ -1,0 +1,46 @@
+require 'dk/task'
+require 'much-plugin'
+require 'dk-pkg/constants'
+require 'dk-pkg/validate'
+
+module Dk::Pkg
+
+  module InstallPkg
+    include MuchPlugin
+
+    plugin_included do
+      include Dk::Task
+      include InstanceMethods
+
+      before Dk::Pkg::Validate
+
+    end
+
+    module InstanceMethods
+
+      private
+
+      def install_pkg(name)
+        raise(ArgumentError, "a pkg name must be provided") if name.to_s.empty?
+        raise(ArgumentError, "no block given") unless block_given?
+
+        if !params[INSTALLED_PKGS_PARAM_NAME].include?(name)
+          yield
+          dk_pkg_write_pkg_to_manifest(name)
+        else
+          log_info "#{name.inspect} has already been installed"
+        end
+      end
+
+      def dk_pkg_write_pkg_to_manifest(name)
+        pkgs = params[INSTALLED_PKGS_PARAM_NAME] + [name]
+        serialized_pkgs = Manifest.serialize(pkgs)
+        cmd!("tee #{params[MANIFEST_PATH_PARAM_NAME]}", serialized_pkgs)
+        set_param INSTALLED_PKGS_PARAM_NAME, Manifest.deserialize(serialized_pkgs)
+      end
+
+    end
+
+  end
+
+end

--- a/lib/dk-pkg/manifest.rb
+++ b/lib/dk-pkg/manifest.rb
@@ -1,0 +1,27 @@
+require 'dk-pkg/constants'
+
+module Dk::Pkg
+
+  module Manifest
+
+    def self.serialize(pkgs)
+      raise ArgumentError, "pkgs must be an array" if !pkgs.kind_of?(Array)
+      sanitize_array(pkgs).join(MANIFEST_SEPARATOR)
+    end
+
+    def self.deserialize(serialized_pkgs)
+      if !serialized_pkgs.kind_of?(String)
+        raise ArgumentError, "serialized pkgs must be a string"
+      end
+      sanitize_array(serialized_pkgs.split(MANIFEST_SEPARATOR))
+    end
+
+    private
+
+    def self.sanitize_array(array)
+      array.compact.uniq.map(&:to_s).reject(&:empty?).sort
+    end
+
+  end
+
+end

--- a/lib/dk-pkg/validate.rb
+++ b/lib/dk-pkg/validate.rb
@@ -1,5 +1,6 @@
 require 'dk/task'
 require 'dk-pkg/constants'
+require 'dk-pkg/manifest'
 
 module Dk::Pkg
 
@@ -17,8 +18,8 @@ module Dk::Pkg
       end
 
       cmd! "touch #{params[MANIFEST_PATH_PARAM_NAME]}"
-      manifest = cmd!("cat #{params[MANIFEST_PATH_PARAM_NAME]}").stdout
-      set_param INSTALLED_PKGS_PARAM_NAME, manifest.split(MANIFEST_SEPARATOR)
+      serialized_pkgs = cmd!("cat #{params[MANIFEST_PATH_PARAM_NAME]}").stdout
+      set_param INSTALLED_PKGS_PARAM_NAME, Manifest.deserialize(serialized_pkgs)
     end
 
     module TestHelpers

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,16 +1,11 @@
 require 'assert/factory'
-require 'dk-pkg/constants'
+require 'dk-pkg/manifest'
 
 module Factory
   extend Assert::Factory
 
-  def self.manifest(installed_pkgs = nil)
-    installed_pkgs ||= Factory.installed_pkgs
-    installed_pkgs.join(Dk::Pkg::MANIFEST_SEPARATOR)
-  end
-
-  def self.installed_pkgs
-    Factory.integer(3).times.map{ Factory.string }
+  def self.manifest_pkgs
+    Factory.integer(3).times.map{ Factory.string }.sort
   end
 
 end

--- a/test/unit/install_pkg_tests.rb
+++ b/test/unit/install_pkg_tests.rb
@@ -1,0 +1,93 @@
+require 'assert'
+require 'dk-pkg/install_pkg'
+
+require 'dk/task'
+require 'much-plugin'
+require 'dk-pkg/constants'
+require 'dk-pkg/validate'
+
+module Dk::Pkg::InstallPkg
+
+  class UnitTests < Assert::Context
+    include Dk::Pkg::Validate::TestHelpers
+
+    desc "Dk::Pkg::InstallPkg"
+    subject{ Dk::Pkg::InstallPkg }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, subject
+    end
+
+  end
+
+  class MixinTests < UnitTests
+    desc "mixin"
+    setup do
+      @task_class = Class.new{ include Dk::Pkg::InstallPkg }
+    end
+    subject{ @task_class }
+
+    should "be a Dk::Task" do
+      assert_includes Dk::Task, subject
+    end
+
+    should "run the Validate task as a before callback" do
+      assert_equal [Dk::Pkg::Validate], subject.before_callback_task_classes
+    end
+
+  end
+
+  class InitTests < MixinTests
+    desc "when init"
+    setup do
+      @task_class.class_eval do
+        def run!
+          install_pkg params['pkg-name'] do
+            set_param 'install-pkg-yielded', true
+          end
+        end
+      end
+      @params['pkg-name']            = Factory.string
+      @params['install-pkg-yielded'] = false
+
+      @runner = test_runner(@task_class, :params => @params)
+    end
+    subject{ @runner }
+
+    should "provide an install pkg helper" do
+      subject.run
+
+      assert_true subject.params['install-pkg-yielded']
+      # there will always be +1 because of the Validate task being run
+      assert_equal 2, subject.runs.size
+      tee_cmd = subject.runs.last
+      assert_equal "tee #{@dk_pkg_manifest_path}", tee_cmd.cmd_str
+
+      exp_pkgs = [@params['pkg-name']]
+      assert_equal Dk::Pkg::Manifest.serialize(exp_pkgs), tee_cmd.run_input
+
+      assert_equal exp_pkgs, subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
+    end
+
+    should "not yield or run any commands if the pkg is already installed" do
+      @params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME] << @params['pkg-name']
+      runner = test_runner(@task_class, :params => @params)
+      runner.run
+
+      assert_false runner.params['install-pkg-yielded']
+      # there will always be +1 because of the Validate task being run
+      assert_equal 1, runner.runs.size
+    end
+
+    should "complain if passed invalid args" do
+      assert_raises(ArgumentError) do
+        subject.task.instance_eval{ install_pkg([nil, ''].choice){ } }
+      end
+      assert_raises(ArgumentError) do
+        subject.task.instance_eval{ install_pkg(Factory.string) }
+      end
+    end
+
+  end
+
+end

--- a/test/unit/manifest_tests.rb
+++ b/test/unit/manifest_tests.rb
@@ -1,0 +1,63 @@
+require 'assert'
+require 'dk-pkg/manifest'
+
+require 'dk-pkg/constants'
+
+module Dk::Pkg::Manifest
+
+  class UnitTests < Assert::Context
+    desc "Dk::Pkg::Manifest"
+    setup do
+      @pkgs = Factory.manifest_pkgs
+    end
+    subject{ Dk::Pkg::Manifest }
+
+    should have_imeths :serialize, :deserialize
+
+    should "know how to serialize and deserialize" do
+      exp = @pkgs.join(Dk::Pkg::MANIFEST_SEPARATOR)
+      serialized_pkgs = subject.serialize(@pkgs)
+      assert_equal exp, serialized_pkgs
+      assert_equal @pkgs, subject.deserialize(serialized_pkgs)
+    end
+
+    should "clean pkg names using serialize/deserialize" do
+      valid_pkgs      = Factory.manifest_pkgs.shuffle # randomize their order
+      non_string_pkgs = [Factory.integer, Factory.boolean, Factory.float]
+      duplicate_pkg   = Factory.string
+      pkgs = valid_pkgs +
+             non_string_pkgs +                        # add non strings
+             ([duplicate_pkg] * Factory.integer(3)) + # add duplicates
+             ([nil] * Factory.integer(3)) +           # add `nil` packages
+             ([""] * Factory.integer(3))              # add empty string packages
+      serialized_pkgs = pkgs.shuffle.join(Dk::Pkg::MANIFEST_SEPARATOR)
+
+      exp_pkgs            = (valid_pkgs + non_string_pkgs + [duplicate_pkg]).map(&:to_s).sort
+      exp_serialized_pkgs = exp_pkgs.join(Dk::Pkg::MANIFEST_SEPARATOR)
+
+      assert_equal exp_serialized_pkgs, subject.serialize(pkgs)
+      assert_equal exp_pkgs,            subject.deserialize(serialized_pkgs)
+    end
+
+    should "handle special cases using serialize/deserialize" do
+      # a single item
+      pkg = Factory.string
+      assert_equal pkg,   subject.serialize([pkg])
+      assert_equal [pkg], subject.deserialize(pkg)
+
+      assert_equal "", subject.serialize([])
+      assert_equal [], subject.deserialize("")
+    end
+
+    should "complain if serialize/deserialize is passed invalid args" do
+      assert_raises(ArgumentError){ subject.serialize(nil) }
+      assert_raises(ArgumentError){ subject.serialize(Factory.string) }
+
+      assert_raises(ArgumentError){ subject.deserialize(nil) }
+      array = Factory.integer(3).times.map{ Factory.string }
+      assert_raises(ArgumentError){ subject.deserialize(array) }
+    end
+
+  end
+
+end

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -3,6 +3,7 @@ require 'dk-pkg/validate'
 
 require 'dk/task'
 require 'dk-pkg/constants'
+require 'dk-pkg/manifest'
 
 class Dk::Pkg::Validate
 
@@ -34,7 +35,7 @@ class Dk::Pkg::Validate
     desc "when run"
     setup do
       @manifest_path  = Factory.file_path
-      @installed_pkgs = Factory.installed_pkgs
+      @installed_pkgs = Factory.manifest_pkgs
 
       @exp_cat_cmd = "cat #{@manifest_path}"
 
@@ -47,7 +48,7 @@ class Dk::Pkg::Validate
     private
 
     def stub_cat_manifest_file_cmd(runner, manifest = nil)
-      manifest ||= Factory.manifest(@installed_pkgs)
+      manifest ||= Dk::Pkg::Manifest.serialize(@installed_pkgs)
       runner.stub_cmd(@exp_cat_cmd){ |s| s.stdout = manifest }
     end
 


### PR DESCRIPTION
This adds an `InstallPkg` mixin for allowing tasks to install pkgs
using dk-pkg. This will allow tasks to group a set of running
tasks or commands as the steps to install a pkg. The mixin will
then track if that pkg has been installed and if so it won't try
to install it again. This will allow re-running groups of tasks
without worrying about messing up any existing pkgs that have
already been installed.

The `InstallPkg` mixin adds a private `install_pkg` helper method
which takes a pkg name and a block. The method will check if the
pkg name is in the installed pkgs param and if not, it will yield
to the block. After the block finishes the `install_pkg` method
will add the pkg name to the installed pkgs and run a command to
update the manifest file on disk. If the pkg name is included in
the install pkgs param then the block isn't run and it simply
logs that its already installed. This ensures that if the pkg is
encountered again (in the current or a subsequent run) then it
won't try to run the package's cmds again which could cause
problems.

The `InstallPkg` mixin also adds the `Validate` task as a before
callback which ensures that the current dk run has the manifest
file path configured and has parsed it. This ensures that the
`install_pkg` helper can work as expected.

This also breaks out the logic for reading and writing the manifest
into a `Manifest` module with serialize and deserialize methods.
The `Validate` task uses the deserialize method on the contents of
the manifest file. The `InstallPkg` mixin uses the serialize method
to write the manifest file after a pkg has been installed. This
centralizes the serialization logic and adds logic to clean the
pkgs when serializing/deserializing. This keeps the manifest file
clean and avoids edge cases that could cause errors.

@kellyredding - FYI, moar importing logic and history from other repo
