### PR TITLE
Add `TestHelpers` to `InstallPkg`

### DIFF
--- a/lib/dk-pkg/install_pkg.rb
+++ b/lib/dk-pkg/install_pkg.rb
@@ -8,6 +8,8 @@ module Dk::Pkg
   module InstallPkg
     include MuchPlugin
 
+    WRITE_MANIFEST_CMD_STR_PROC = proc{ |manifest_path| "tee #{manifest_path}" }
+
     plugin_included do
       include Dk::Task
       include InstanceMethods
@@ -35,8 +37,43 @@ module Dk::Pkg
       def dk_pkg_write_pkg_to_manifest(name)
         pkgs = params[INSTALLED_PKGS_PARAM_NAME] + [name]
         serialized_pkgs = Manifest.serialize(pkgs)
-        cmd!("tee #{params[MANIFEST_PATH_PARAM_NAME]}", serialized_pkgs)
+        cmd!(
+          WRITE_MANIFEST_CMD_STR_PROC.call(params[MANIFEST_PATH_PARAM_NAME]),
+          serialized_pkgs
+        )
         set_param INSTALLED_PKGS_PARAM_NAME, Manifest.deserialize(serialized_pkgs)
+      end
+
+    end
+
+    module TestHelpers
+      include MuchPlugin
+
+      plugin_included do
+        include Dk::Pkg::Validate::TestHelpers
+        include InstanceMethods
+
+      end
+
+      module InstanceMethods
+
+        def assert_dk_pkg_installed(test_runner, pkg_name)
+          assert_includes pkg_name, test_runner.params[INSTALLED_PKGS_PARAM_NAME]
+        end
+
+        def non_dk_install_pkg_runs(test_runner)
+          manifest_path          = test_runner.params[MANIFEST_PATH_PARAM_NAME]
+          write_manifest_cmd_str = WRITE_MANIFEST_CMD_STR_PROC.call(manifest_path)
+
+          test_runner.runs.reject do |run|
+            validate_task_run  = run.kind_of?(Dk::TaskRun) &&
+                                 run.task_class == Dk::Pkg::Validate
+            write_manifest_cmd = run.kind_of?(Dk::Local::CmdSpy) &&
+                                 run.cmd_str == write_manifest_cmd_str
+            validate_task_run || write_manifest_cmd
+          end
+        end
+
       end
 
     end

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -121,7 +121,7 @@ class Dk::Pkg::Validate
     subject{ @context }
 
     should "use much-plugin" do
-      assert_includes MuchPlugin, @context_class
+      assert_includes MuchPlugin, Dk::Pkg::Validate::TestHelpers
     end
 
     should "setup the ivars and params the validate task does" do


### PR DESCRIPTION
This updates the `InstallPkg` mixin to provide test helpers. These
are needed to make testing tasks that use the mixin easier.

The test helpers provide a helper method for testing that a package
was installed using the `install_pkg` method and a method for
removing `InstallPkg` runs from the test runner. The test runner's
runs will include any task callbacks that `InstallPkg` adds and any
cmds that `install_pkg` runs. To avoid having to worry about these,
the `non_dk_install_pkg_runs` method will take a test runner and
remove runs that the install pkg logic caused. The runs array that
is returned can then be used normally to test which cmds or tasks
were run.

This also includes a minor test change to the
`Validate::TestHelpers` tests to ensure the test helpers mixin is
using `MuchPlugin`. Previously the class that the test helpers were mixed
into it was being tested for `MuchPlugin`.

@kellyredding - FYI moar importing
