### PR TITLE
Don't set manifest path ivar in `Validate::TestHelpers`

### DIFF
--- a/lib/dk-pkg/validate.rb
+++ b/lib/dk-pkg/validate.rb
@@ -29,11 +29,10 @@ module Dk::Pkg
         include Dk::Task::TestHelpers
 
         setup do
-          @dk_pkg_manifest_path  ||= Factory.file_path
           @dk_pkg_installed_pkgs ||= []
 
           @params ||= {}
-          @params[MANIFEST_PATH_PARAM_NAME]  ||= @dk_pkg_manifest_path
+          @params[MANIFEST_PATH_PARAM_NAME]  ||= Factory.file_path
           @params[INSTALLED_PKGS_PARAM_NAME] ||= @dk_pkg_installed_pkgs
         end
 

--- a/test/unit/install_pkg_tests.rb
+++ b/test/unit/install_pkg_tests.rb
@@ -61,7 +61,8 @@ module Dk::Pkg::InstallPkg
       # there will always be +1 because of the Validate task being run
       assert_equal 2, subject.runs.size
       tee_cmd = subject.runs.last
-      assert_equal "tee #{@dk_pkg_manifest_path}", tee_cmd.cmd_str
+      exp = "tee #{@params[Dk::Pkg::MANIFEST_PATH_PARAM_NAME]}"
+      assert_equal exp, tee_cmd.cmd_str
 
       exp_pkgs = [@params['pkg-name']]
       assert_equal Dk::Pkg::Manifest.serialize(exp_pkgs), tee_cmd.run_input

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -110,8 +110,7 @@ class Dk::Pkg::Validate
           self.setup_blocks << block
         end
         include Dk::Pkg::Validate::TestHelpers
-        attr_reader :dk_pkg_manifest_path, :dk_pkg_installed_pkgs
-        attr_reader :params
+        attr_reader :dk_pkg_installed_pkgs, :params
         def initialize
           self.class.setup_blocks.each{ |b| self.instance_eval(&b) }
         end
@@ -124,9 +123,8 @@ class Dk::Pkg::Validate
       assert_includes MuchPlugin, Dk::Pkg::Validate::TestHelpers
     end
 
-    should "setup the ivars and params the validate task does" do
-      exp = subject.dk_pkg_manifest_path
-      assert_equal exp, subject.params[Dk::Pkg::MANIFEST_PATH_PARAM_NAME]
+    should "setup the ivars and params the validate task needs" do
+      assert_not_nil subject.params[Dk::Pkg::MANIFEST_PATH_PARAM_NAME]
 
       exp = subject.dk_pkg_installed_pkgs
       assert_equal exp, subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]


### PR DESCRIPTION
This updates `Validate::TestHelpers` to not set a manifest path
ivar and only conditionally set the manifest path param. This is
to allow apps using dk-pkg to set their own manifest path and use
that in the tests. This helps avoid confusion where the
`@dk_pkg_manifest_path` ivar is set but it doesn't match what is
in the params. This is also makes the test helpers more closely
match the live code in that the `Validate` task doesn't set a
manifest path.

@kellyredding - FYI moar importing
