### PR TITLE
Allow setting the manifest mode and owner

### DIFF
--- a/lib/dk-pkg/constants.rb
+++ b/lib/dk-pkg/constants.rb
@@ -2,6 +2,8 @@ module Dk; end
 module Dk::Pkg
 
   MANIFEST_PATH_PARAM_NAME  = 'dk_pkg_manifest_path'.freeze
+  MANIFEST_MODE_PARAM_NAME  = 'dk_pkg_manifest_mode'.freeze
+  MANIFEST_OWNER_PARAM_NAME = 'dk_pkg_manifest_owner'.freeze
   INSTALLED_PKGS_PARAM_NAME = 'dk_pkg_installed_pkgs'.freeze
 
   MANIFEST_SEPARATOR = "\n".freeze

--- a/lib/dk-pkg/validate.rb
+++ b/lib/dk-pkg/validate.rb
@@ -17,7 +17,17 @@ module Dk::Pkg
         raise ArgumentError, "no #{MANIFEST_PATH_PARAM_NAME.inspect} param set"
       end
 
-      cmd! "touch #{params[MANIFEST_PATH_PARAM_NAME]}"
+      if !cmd("test -e #{params[MANIFEST_PATH_PARAM_NAME]}").success?
+        cmd! "touch #{params[MANIFEST_PATH_PARAM_NAME]}"
+        if param?(MANIFEST_MODE_PARAM_NAME)
+          cmd! "chmod #{params[MANIFEST_MODE_PARAM_NAME]} " \
+                     "#{params[MANIFEST_PATH_PARAM_NAME]}"
+        end
+        if param?(MANIFEST_OWNER_PARAM_NAME)
+          cmd! "chown #{params[MANIFEST_OWNER_PARAM_NAME]} " \
+                     "#{params[MANIFEST_PATH_PARAM_NAME]}"
+        end
+      end
       serialized_pkgs = cmd!("cat #{params[MANIFEST_PATH_PARAM_NAME]}").stdout
       set_param INSTALLED_PKGS_PARAM_NAME, Manifest.deserialize(serialized_pkgs)
     end

--- a/test/unit/dk-pkg_tests.rb
+++ b/test/unit/dk-pkg_tests.rb
@@ -12,6 +12,8 @@ module Dk::Pkg
 
     should "know its param names" do
       assert_equal 'dk_pkg_manifest_path',  MANIFEST_PATH_PARAM_NAME
+      assert_equal 'dk_pkg_manifest_mode',  MANIFEST_MODE_PARAM_NAME
+      assert_equal 'dk_pkg_manifest_owner', MANIFEST_OWNER_PARAM_NAME
       assert_equal 'dk_pkg_installed_pkgs', INSTALLED_PKGS_PARAM_NAME
     end
 

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -35,17 +35,26 @@ class Dk::Pkg::Validate
     desc "when run"
     setup do
       @manifest_path  = Factory.file_path
+      @manifest_mode  = Factory.string
+      @manifest_owner = Factory.string
       @installed_pkgs = Factory.manifest_pkgs
 
-      @exp_cat_cmd = "cat #{@manifest_path}"
+      @exp_test_cmd = "test -e #{@manifest_path}"
+      @exp_cat_cmd  = "cat #{@manifest_path}"
 
       @params = {
-        Dk::Pkg::MANIFEST_PATH_PARAM_NAME => @manifest_path
+        Dk::Pkg::MANIFEST_PATH_PARAM_NAME  => @manifest_path,
+        Dk::Pkg::MANIFEST_MODE_PARAM_NAME  => @manifest_mode,
+        Dk::Pkg::MANIFEST_OWNER_PARAM_NAME => @manifest_owner
       }
     end
     subject{ @runner }
 
     private
+
+    def stub_test_manifest_file_exists_cmd(runner, success)
+      @runner.stub_cmd(@exp_test_cmd){ |s| s.exitstatus = success ? 0 : 1 }
+    end
 
     def stub_cat_manifest_file_cmd(runner, manifest = nil)
       manifest ||= Dk::Pkg::Manifest.serialize(@installed_pkgs)
@@ -57,16 +66,20 @@ class Dk::Pkg::Validate
   class RunTests < RunSetupTests
     setup do
       @runner = test_runner(@task_class, :params => @params)
+      stub_test_manifest_file_exists_cmd(@runner, false)
       stub_cat_manifest_file_cmd(@runner)
       @runner.run
     end
 
     should "parse the manifest file and set the installed pkgs param" do
-      assert_equal 2, subject.runs.size
+      assert_equal 5, subject.runs.size
 
-      touch_cmd, cat_cmd = subject.runs
-      assert_equal "touch #{@manifest_path}", touch_cmd.cmd_str
-      assert_equal @exp_cat_cmd,              cat_cmd.cmd_str
+      test_cmd, touch_cmd, chmod_cmd, chown_cmd, cat_cmd = subject.runs
+      assert_equal @exp_test_cmd,                                test_cmd.cmd_str
+      assert_equal "touch #{@manifest_path}",                    touch_cmd.cmd_str
+      assert_equal "chmod #{@manifest_mode} #{@manifest_path}",  chmod_cmd.cmd_str
+      assert_equal "chown #{@manifest_owner} #{@manifest_path}", chown_cmd.cmd_str
+      assert_equal @exp_cat_cmd,                                 cat_cmd.cmd_str
 
       exp = @installed_pkgs
       assert_equal exp, subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
@@ -78,12 +91,61 @@ class Dk::Pkg::Validate
     desc "and the manifest is empty"
     setup do
       @runner = test_runner(@task_class, :params => @params)
+      stub_test_manifest_file_exists_cmd(@runner, Factory.boolean)
       stub_cat_manifest_file_cmd(@runner, "")
       @runner.run
     end
 
     should "parse the manifest file and set the installed pkgs param" do
       assert_equal [], subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
+    end
+
+  end
+
+  class RunWithExistingManifestTests < RunSetupTests
+    desc "and the manifest already exists"
+    setup do
+      @runner = test_runner(@task_class, :params => @params)
+      stub_test_manifest_file_exists_cmd(@runner, true)
+      stub_cat_manifest_file_cmd(@runner)
+      @runner.run
+    end
+
+    should "not create the manifest file but still parse it" do
+      assert_equal 2, subject.runs.size
+
+      test_cmd, cat_cmd = subject.runs
+      assert_equal @exp_test_cmd, test_cmd.cmd_str
+      assert_equal @exp_cat_cmd,  cat_cmd.cmd_str
+
+      exp = @installed_pkgs
+      assert_equal exp, subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
+    end
+
+  end
+
+  class RunOnNewWithoutModeOrOwnerParamsTests < RunSetupTests
+    desc "with a new manifest but no mode/owner params set"
+    setup do
+      @params.delete(Dk::Pkg::MANIFEST_MODE_PARAM_NAME)
+      @params.delete(Dk::Pkg::MANIFEST_OWNER_PARAM_NAME)
+
+      @runner = test_runner(@task_class, :params => @params)
+      stub_test_manifest_file_exists_cmd(@runner, false)
+      stub_cat_manifest_file_cmd(@runner)
+      @runner.run
+    end
+
+    should "create the manifest file but not change its mode/owner" do
+      assert_equal 3, subject.runs.size
+
+      test_cmd, touch_cmd, cat_cmd = subject.runs
+      assert_equal @exp_test_cmd,             test_cmd.cmd_str
+      assert_equal "touch #{@manifest_path}", touch_cmd.cmd_str
+      assert_equal @exp_cat_cmd,              cat_cmd.cmd_str
+
+      exp = @installed_pkgs
+      assert_equal exp, subject.params[Dk::Pkg::INSTALLED_PKGS_PARAM_NAME]
     end
 
   end


### PR DESCRIPTION
This adds a manifest mode and owner param that are used when the
manifest is created. If these are provided then when the manifest
is created it will `chmod` and `chown` the manifest file. If these
aren't provided then no `chmod` or `chown` cmds are run for the
manifest file. This allows more control over the manifest file and
its mode/owner.

The `Validate` task now uses the new params when it creates a
manifest file. It will now test if the manifest file exists and if
it doesn't, it will create it and optionally `chmod` and `chown`
it using the params. The `Validate` task will not modify the
mode or owner of the manifest file after it has been created.

@kellyredding - FYI
