### PR TITLE
Allow passing runs to `non_dk_install_pkg_runs`

### DIFF
--- a/lib/dk-pkg/install_pkg.rb
+++ b/lib/dk-pkg/install_pkg.rb
@@ -61,11 +61,11 @@ module Dk::Pkg
           assert_includes pkg_name, test_runner.params[INSTALLED_PKGS_PARAM_NAME]
         end
 
-        def non_dk_install_pkg_runs(test_runner)
+        def non_dk_install_pkg_runs(test_runner, test_runner_runs)
           manifest_path          = test_runner.params[MANIFEST_PATH_PARAM_NAME]
           write_manifest_cmd_str = WRITE_MANIFEST_CMD_STR_PROC.call(manifest_path)
 
-          test_runner.runs.reject do |run|
+          test_runner_runs.reject do |run|
             validate_task_run  = run.kind_of?(Dk::TaskRun) &&
                                  run.task_class == Dk::Pkg::Validate
             write_manifest_cmd = run.kind_of?(Dk::Local::CmdSpy) &&

--- a/test/unit/install_pkg_tests.rb
+++ b/test/unit/install_pkg_tests.rb
@@ -27,7 +27,7 @@ module Dk::Pkg::InstallPkg
     end
     subject{ @task_class }
 
-    should "be a Dk::Task" do
+    should "be a Dk task" do
       assert_includes Dk::Task, subject
     end
 
@@ -82,7 +82,7 @@ module Dk::Pkg::InstallPkg
 
     should "complain if passed invalid args" do
       assert_raises(ArgumentError) do
-        subject.task.instance_eval{ install_pkg([nil, ''].choice){ } }
+        subject.task.instance_eval{ install_pkg([nil, ''].sample){ } }
       end
       assert_raises(ArgumentError) do
         subject.task.instance_eval{ install_pkg(Factory.string) }
@@ -147,7 +147,7 @@ module Dk::Pkg::InstallPkg
     end
 
     should "know how to select non dk-pkg install pkg runs" do
-      runs = subject.non_dk_install_pkg_runs(@runner)
+      runs = subject.non_dk_install_pkg_runs(@runner, @runner.runs)
       assert_not_equal runs, @runner.runs
       assert_equal @params['pkgs'].size + 1, runs.size
       cmd_runs = runs[0, @params['pkgs'].size]

--- a/test/unit/validate_tests.rb
+++ b/test/unit/validate_tests.rb
@@ -14,7 +14,7 @@ class Dk::Pkg::Validate
     end
     subject{ @task_class }
 
-    should "be a Dk::Task" do
+    should "be a Dk task" do
       assert_includes Dk::Task, subject
     end
 


### PR DESCRIPTION
This updates the `non_dk_install_pkg_runs` test helper to expect
it will be passed a collection of runs instead of always using the
runs from the runner that is passed to it. By taking a runs array
and returning a filtered runs array the test helper can be chained
together with other helpers that filter the runs array. This allows
a task's tests to filter out any runs that are not specific to it
which makes testing easier.

This also includes a ruby 2.3.1 cleanup so that the test suite
runs on the newer version of ruby.

@kellyredding - FYI, this is the last of the commits that needed to be imported
